### PR TITLE
fixes for building on E2K

### DIFF
--- a/engine/voice_codecs/minimp3/minimp3.h
+++ b/engine/voice_codecs/minimp3/minimp3.h
@@ -180,6 +180,31 @@ static int have_simd()
 {   /* TODO: detect neon for !MINIMP3_ONLY_SIMD */
     return 1;
 }
+#elif defined(__e2k__)
+#ifdef __SSE___
+#include <x86intrin.h>
+#define HAVE_SSE 1
+#define HAVE_SIMD 1
+#define VSTORE _mm_storeu_ps
+#define VLD _mm_loadu_ps
+#define VSET _mm_set1_ps
+#define VADD _mm_add_ps
+#define VSUB _mm_sub_ps
+#define VMUL _mm_mul_ps
+#define VMAC(a, x, y) _mm_add_ps(a, _mm_mul_ps(x, y))
+#define VMSB(a, x, y) _mm_sub_ps(a, _mm_mul_ps(x, y))
+#define VMUL_S(x, s)  _mm_mul_ps(x, _mm_set1_ps(s))
+#define VREV(x) _mm_shuffle_ps(x, x, _MM_SHUFFLE(0, 1, 2, 3))
+typedef __m128 f4;
+static int have_simd()
+{
+    return 1;
+}
+#else /* __SSE__ */
+#undef MINIMP3_ONLY_SIMD
+#define HAVE_SSE 0
+#define HAVE_SIMD 0
+#endif /* __SSE__ */
 #else /* SIMD checks... */
 #define HAVE_SSE 0
 #define HAVE_SIMD 0

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 project(launcher)
 set(SRCDIR "${CMAKE_SOURCE_DIR}")
 set(CMAKE_MODULE_PATH ${SRCDIR}/cmake)
-set(OUTBINNAME "launcher")
+set(OUTBINNAME "launcher_client")
 set(OUTBINDIR ${SRCDIR}/../game/bin)
 
 set(NOSTINKYLINKIES "1") #link this project carefully ourselves

--- a/materialsystem/shadersystem.cpp
+++ b/materialsystem/shadersystem.cpp
@@ -315,8 +315,8 @@ void CShaderSystem::LoadAllShaderDLLs( )
 #if defined( _PS3 ) || defined( _OSX )
 	LoadShaderDLL( "stdshader_dx9" DLL_EXT_STRING );
 #else // _PS3 || _OSX
-#if !defined(__e2k__) || !defined( DEDICATED ) // Don't load stdshader_dbg module on Elbrus (prevent "Module stdshader_dbg failed to load! Error: ((null))" message)
-	// 360 has the the debug shaders in its dx9 dll
+#if !defined(DEDICATED) && !defined(__e2k__) // Don't load stdshader_dbg module on build as a DEDICATED server AND on any Elbrus build (prevent "Module stdshader_dbg failed to load! Error: ((null))" message)
+	// 360 has the debug shaders in its dx9 dll
 	if ( IsPC() || !IsX360() )
 	{
 		// Always need the debug shaders

--- a/thirdparty/protobuf-3.5.1/src/google/protobuf/stubs/atomicops.h
+++ b/thirdparty/protobuf-3.5.1/src/google/protobuf/stubs/atomicops.h
@@ -213,6 +213,8 @@ Atomic64 Release_Load(volatile const Atomic64* ptr);
 #include <google/protobuf/stubs/atomicops_internals_generic_c11_atomic.h>
 #elif defined(GOOGLE_PROTOBUF_ARCH_PPC)
 #include <google/protobuf/stubs/atomicops_internals_ppc_gcc.h>
+#elif defined(GOOGLE_PROTOBUF_ARCH_E2K)
+#include <google/protobuf/stubs/atomicops_internals_e2k_lcc.h>
 #elif (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4))
 #include <google/protobuf/stubs/atomicops_internals_generic_gcc.h>
 #elif defined(__clang__)

--- a/thirdparty/protobuf-3.5.1/src/google/protobuf/stubs/atomicops_internals_e2k_lcc.h
+++ b/thirdparty/protobuf-3.5.1/src/google/protobuf/stubs/atomicops_internals_e2k_lcc.h
@@ -1,0 +1,163 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2012 Google Inc.  All rights reserved.
+// http://code.google.com/p/protobuf/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// This file is an internal atomic implementation, use atomicops.h instead.
+//
+// LinuxKernelCmpxchg and Barrier_AtomicIncrement are from Google Gears.
+
+#ifndef GOOGLE_PROTOBUF_ATOMICOPS_INTERNALS_E2K_LCC_H_
+#define GOOGLE_PROTOBUF_ATOMICOPS_INTERNALS_E2K_LCC_H_
+
+namespace google {
+namespace protobuf {
+namespace internal {
+
+inline Atomic32 NoBarrier_CompareAndSwap(volatile Atomic32* ptr,
+                                         Atomic32 old_value,
+                                         Atomic32 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+  return old_value;
+}
+
+inline Atomic32 NoBarrier_AtomicExchange(volatile Atomic32* ptr,
+                                         Atomic32 new_value) {
+  return __atomic_exchange_n(ptr, new_value, __ATOMIC_RELAXED);
+}
+
+inline Atomic32 NoBarrier_AtomicIncrement(volatile Atomic32* ptr,
+                                          Atomic32 increment) {
+  return __atomic_add_fetch(ptr, increment, __ATOMIC_RELAXED);
+}
+
+inline Atomic32 Barrier_AtomicIncrement(volatile Atomic32* ptr,
+                                        Atomic32 increment) {
+  return __atomic_add_fetch(ptr, increment, __ATOMIC_SEQ_CST);
+}
+
+inline Atomic32 Acquire_CompareAndSwap(volatile Atomic32* ptr,
+                                       Atomic32 old_value,
+                                       Atomic32 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
+  return old_value;
+}
+
+inline Atomic32 Release_CompareAndSwap(volatile Atomic32* ptr,
+                                       Atomic32 old_value,
+                                       Atomic32 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
+  return old_value;
+}
+
+inline void NoBarrier_Store(volatile Atomic32* ptr, Atomic32 value) {
+  __atomic_store_n(ptr, value, __ATOMIC_RELAXED);
+}
+
+inline void MemoryBarrier() {
+  __sync_synchronize();
+}
+
+inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {
+  __atomic_store_n(ptr, value, __ATOMIC_SEQ_CST);
+}
+
+inline void Release_Store(volatile Atomic32* ptr, Atomic32 value) {
+  __atomic_store_n(ptr, value, __ATOMIC_RELEASE);
+}
+
+inline Atomic32 NoBarrier_Load(volatile const Atomic32* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+}
+
+inline Atomic32 Acquire_Load(volatile const Atomic32* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+}
+
+inline Atomic32 Release_Load(volatile const Atomic32* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_SEQ_CST);
+}
+
+inline void Release_Store(volatile Atomic64* ptr, Atomic64 value) {
+  __atomic_store_n(ptr, value, __ATOMIC_RELEASE);
+}
+
+inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+}
+
+inline Atomic64 Acquire_CompareAndSwap(volatile Atomic64* ptr,
+                                       Atomic64 old_value,
+                                       Atomic64 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE);
+  return old_value;
+}
+
+inline Atomic64 NoBarrier_CompareAndSwap(volatile Atomic64* ptr,
+                                         Atomic64 old_value,
+                                         Atomic64 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+  return old_value;
+}
+
+inline Atomic64 NoBarrier_AtomicIncrement(volatile Atomic64* ptr,
+                                          Atomic64 increment) {
+  return __atomic_add_fetch(ptr, increment, __ATOMIC_RELAXED);
+}
+
+inline void NoBarrier_Store(volatile Atomic64* ptr, Atomic64 value) {
+  __atomic_store_n(ptr, value, __ATOMIC_RELAXED);
+}
+
+inline Atomic64 NoBarrier_AtomicExchange(volatile Atomic64* ptr,
+                                         Atomic64 new_value) {
+  return __atomic_exchange_n(ptr, new_value, __ATOMIC_RELAXED);
+}
+
+inline Atomic64 NoBarrier_Load(volatile const Atomic64* ptr) {
+  return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+}
+
+inline Atomic64 Release_CompareAndSwap(volatile Atomic64* ptr,
+                                       Atomic64 old_value,
+                                       Atomic64 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
+  return old_value;
+}
+
+}  // namespace internal
+}  // namespace protobuf
+}  // namespace google
+
+#endif  // GOOGLE_PROTOBUF_ATOMICOPS_INTERNALS_E2K_LCC_H_

--- a/thirdparty/protobuf-3.5.1/src/google/protobuf/stubs/platform_macros.h
+++ b/thirdparty/protobuf-3.5.1/src/google/protobuf/stubs/platform_macros.h
@@ -79,6 +79,9 @@
 #elif defined(__PPC__)
 #define GOOGLE_PROTOBUF_ARCH_PPC 1
 #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
+#elif defined(__e2k__)
+#define GOOGLE_PROTOBUF_ARCH_E2K 1
+#define GOOGLE_PROTOBUF_ARCH_64_BIT 1
 #elif defined(__GNUC__)
 # if (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)) || (__GNUC__ > 4))
 // We fallback to the generic Clang/GCC >= 4.7 implementation in atomicops.h

--- a/thirdparty/protobuf-3.5.1/src/google/protobuf/stubs/strutil.cc
+++ b/thirdparty/protobuf-3.5.1/src/google/protobuf/stubs/strutil.cc
@@ -386,9 +386,10 @@ int UnescapeCEscapeSequences(const char* source, char* dest,
           const char *hex_start = p;
           while (isxdigit(p[1]))  // arbitrarily many hex digits
             ch = (ch << 4) + hex_digit_to_int(*++p);
-          if (ch > 0xFF)
-            LOG_STRING(ERROR, errors) << "Value of " <<
-              "\\" << string(hex_start, p+1-hex_start) << " exceeds 8 bits";
+          if (ch > 0xFF) {
+            string strt = string(hex_start, p+1-hex_start);
+            LOG_STRING(ERROR, errors) << "Value of " << "\\" << strt.c_str() << " exceeds 8 bits";
+          }
           *d++ = ch;
           break;
         }

--- a/tier1/processor_detect_linux.cpp
+++ b/tier1/processor_detect_linux.cpp
@@ -16,7 +16,7 @@
 // Turn off memdbg macros (turned on up top) since this is included like a header
 #include "tier0/memdbgoff.h"
 
-#if !defined(__e2k__) || !defined(PLATFORM_ARM) // e2k,arm CPUS don't have CPUID
+#if !defined(__e2k__) && !defined(PLATFORM_ARM) // e2k and arm CPUS don't have CPUID
 static void cpuid(uint32 function, uint32& out_eax, uint32& out_ebx, uint32& out_ecx, uint32& out_edx)
 {
 #if defined(PLATFORM_64BITS)
@@ -41,7 +41,7 @@ static void cpuid(uint32 function, uint32& out_eax, uint32& out_ebx, uint32& out
 	);
 #endif
 }
-#endif // ifndef __e2k__
+#endif // ifndef __e2k__ && PLATFORM_ARM
 
 bool CheckMMXTechnology(void)
 {


### PR DESCRIPTION
- thirdparty/protobuf-3.5.1: added e2k support (MCST Elbrus 2000)
- minimp3: added e2k support (MCST Elbrus 2000)
- processor_detect_linux.cpp: fixed check condition for E2K and ARM
- shadersystem.cpp: fixed check condition for E2K
- launcher: library name fixed (fix for https://github.com/tyabus/Kisak-Strike/issues/5)