### PR TITLE
launcher, dedicated: Rename wrong library name

### DIFF
--- a/dedicated_main/main.cpp
+++ b/dedicated_main/main.cpp
@@ -144,10 +144,10 @@ int main( int argc, char *argv[] )
 		return -1;
 	}
 
-	void *vstdlib = dlopen( "libvstdlib" DLL_EXT_STRING, RTLD_NOW );
+	void *vstdlib = dlopen( "vstdlib" DLL_EXT_STRING, RTLD_NOW );
 	if ( !vstdlib )
 	{
-		printf( "Failed to open %s (%s)\n", "libvstdlib" DLL_EXT_STRING, dlerror());
+		printf( "Failed to open %s (%s)\n", "vstdlib" DLL_EXT_STRING, dlerror());
 		return -1;
 	}
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 project(launcher)
 set(SRCDIR "${CMAKE_SOURCE_DIR}")
 set(CMAKE_MODULE_PATH ${SRCDIR}/cmake)
-set(OUTBINNAME "launcher")
+set(OUTBINNAME "launcher_client")
 set(OUTBINDIR ${SRCDIR}/../game/bin)
 
 set(NOSTINKYLINKIES "1") #link this project carefully ourselves


### PR DESCRIPTION
Fix issue #5 and missing libvstdlib_client.so when launching dedicated server 